### PR TITLE
Upgrade TypeScript v5 → v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "postcss-simple-vars": "^7.0.1",
         "timekeeper": "^2.3.1",
         "tsx": "^4.19.2",
-        "typescript": "^5"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -8720,9 +8720,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "postcss-simple-vars": "^7.0.1",
     "timekeeper": "^2.3.1",
     "tsx": "^4.19.2",
-    "typescript": "^5"
+    "typescript": "^6.0.3"
   },
   "overrides": {
     "@types/react": "^19.0.0",


### PR DESCRIPTION
## Summary

- Upgrades `typescript` from `^5` to `^6.0.3`
- Zero type errors confirmed with `tsc --noEmit`

## Test plan

- [ ] `npx tsc --noEmit` passes (verified ✓)
- [ ] `npm run app:dev` starts without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)