### PR TITLE
Add Hardware as a top-level nav page

### DIFF
--- a/src/app/hardware/page.tsx
+++ b/src/app/hardware/page.tsx
@@ -1,0 +1,15 @@
+import App from "../../components/App";
+import { HardwarePage } from "@/components/HardwarePage";
+import { getData } from "@/server/db";
+
+export const dynamic = "force-dynamic";
+
+export default async function Page() {
+  const { nextVersion } = await getData();
+
+  return (
+    <App nextVersion={nextVersion}>
+      <HardwarePage />
+    </App>
+  );
+}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6,6 +6,7 @@ import {
   AppShell,
   Box,
   Burger,
+  Divider,
   Group,
   NavLink,
   Text,
@@ -13,6 +14,7 @@ import {
 import { useDisclosure } from "@mantine/hooks";
 import {
   IconAdjustmentsHorizontal,
+  IconCpu,
   IconDeviceTv,
   IconExclamationCircleFilled,
   IconLayersIntersect,
@@ -110,6 +112,19 @@ function App({
                 style={{ width: "70%", height: "70%" }}
                 stroke={1.5}
               />
+            </ActionIcon>
+          }
+        />
+
+        <Divider my="xs" />
+        <NavLink
+          component={Link}
+          href="/hardware"
+          label="Hardware"
+          active={pathname.includes("/hardware")}
+          leftSection={
+            <ActionIcon variant="light">
+              <IconCpu style={{ width: "70%", height: "70%" }} stroke={1.5} />
             </ActionIcon>
           }
         />

--- a/src/components/HardwarePage.tsx
+++ b/src/components/HardwarePage.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { HardwareState } from "@/types";
+import { Alert, Loader } from "@mantine/core";
+import { useEffect, useState } from "react";
+import { HardwareSettings } from "./HardwareSettings";
+
+export function HardwarePage() {
+  const [hardwareState, setHardwareState] = useState<HardwareState | null>(
+    null,
+  );
+  const [connected, setConnected] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const loop = setInterval(() => {
+      fetch(`http://${window.location.hostname}:3001/api/state`)
+        .then((response) => response.json())
+        .then((data) => {
+          setHardwareState(data);
+          setConnected(true);
+        })
+        .catch(() => setConnected(false));
+    }, 1000);
+
+    return () => clearInterval(loop);
+  }, []);
+
+  if (connected === null) return <Loader />;
+
+  if (!connected)
+    return (
+      <Alert color="gray" title="Hardware not connected">
+        The hardware service is not reachable. Make sure the device is on and
+        the hardware service is running.
+      </Alert>
+    );
+
+  return <HardwareSettings hardwareState={hardwareState} />;
+}

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -16,6 +16,7 @@ import {
   Text,
   useMantineTheme,
 } from "@mantine/core";
+import Link from "next/link";
 import {
   HardwareState,
   Panel as PanelType,
@@ -32,7 +33,6 @@ import {
   createCustomScheduledPreset,
   updateScheduledPreset,
 } from "@/server/actions/scheduledPreset";
-import { HardwareSettings } from "./HardwareSettings";
 import { IconDots } from "@tabler/icons-react";
 import { getFriendlyTimeAdjustmentAmount } from "@/helpers/getFriendlyTimeAdjustmentAmount";
 import { useEffect, useState } from "react";
@@ -55,12 +55,11 @@ export default function Panel({
   customSceneNames,
 }: PanelProps) {
   const [customPresetModalOpen, customPresetModalHandlers] = useDisclosure();
-  const [hardwareModalOpen, hardwareModalHandlers] = useDisclosure();
 
   const [presetEditting, setPresetEditting] = useState<Preset | null>(null);
 
   const [hardwareState, setHardwareState] = useState<HardwareState | null>(
-    null
+    null,
   );
 
   const theme = useMantineTheme();
@@ -78,7 +77,7 @@ export default function Panel({
   const timeAdjustment = parseInt(
     scheduledPreset?.preset?.[PresetField.TimeAdjustmentAmount] ||
       panel.timeAdjustmentAmount,
-    10
+    10,
   );
 
   return (
@@ -103,23 +102,17 @@ export default function Panel({
           submitLabel={scheduledPreset?.preset?.id ? "Update" : "Apply now"}
         />
       </Modal>
-      <Modal
-        title="Hardware Status"
-        opened={hardwareModalOpen}
-        onClose={hardwareModalHandlers.close}
-      >
-        <HardwareSettings hardwareState={hardwareState} />
-      </Modal>
       {isFrameRateLagging(hardwareState) && (
         <Alert color="red" p="xs" mb="md">
           <Stack>
             <Group justify="space-between" w="100%">
               <Text c={theme.colors.red[5]}>Framerate is lagging!</Text>
               <Button
+                component={Link}
+                href="/hardware"
                 variant="light"
                 color="red"
                 size="compact-sm"
-                onClick={hardwareModalHandlers.open}
               >
                 More..
               </Button>
@@ -174,9 +167,6 @@ export default function Panel({
                   }}
                 >
                   Clear Panel
-                </Menu.Item>
-                <Menu.Item onClick={hardwareModalHandlers.open}>
-                  Hardware...
                 </Menu.Item>
               </Menu.Dropdown>
             </Menu>


### PR DESCRIPTION
## Summary
- Moves hardware status out of the Panel `...` dropdown and into its own `/hardware` route
- Adds Hardware as the last nav item in the sidebar with a divider above it
- Handles disconnected state with a loading spinner and a descriptive alert

## Test plan
- [ ] Navigate to /hardware with hardware connected — status and framerate chart display
- [ ] Navigate to /hardware with hardware disconnected — spinner briefly then alert shown
- [ ] Panel page no longer has a `...` menu with Hardware option
- [ ] Framerate lagging alert "More.." button navigates to /hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)