### PR TITLE
Fix update script cleanup and logging

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,4 +90,6 @@ sudo ln -sf "$APP_FOLDER/current/bin/mc" /usr/local/bin/mc
 
 echo "" > $DATA_FOLDER/current_install_step.txt
 
+sudo rm -fr /usr/local/bin/moonclock/update
+
 sudo mc restart

--- a/src/server/actions/app.ts
+++ b/src/server/actions/app.ts
@@ -26,10 +26,8 @@ export async function startUpdate() {
       sudo mkdir -p "/usr/local/bin/moonclock/update" &&
       sudo tar -xzvf ${absoluteFilePath} --strip-components=1 -C "/usr/local/bin/moonclock/update" &&
       cd /usr/local/bin/moonclock/update/ &&
-      sudo ./install.sh &&
-      sudo mc restart &&
-      sudo rm -fr /usr/local/bin/moonclock/update
-    } 2>&1 | tee /tmp/moonclock-update.log`);
+      sudo ./install.sh
+    } 2>&1 | while IFS= read -r line; do echo "[$(date '+%Y-%m-%d %H:%M:%S')] $line"; done | tee /tmp/moonclock-update.log`);
   } catch (e) {
     console.log("Error trying to update!", e);
     return false;


### PR DESCRIPTION
## Summary
- Moves `rm -rf /usr/local/bin/moonclock/update` into `install.sh` before `mc restart`, so cleanup runs while the process is still alive — systemd kills the entire cgroup on service restart, so anything after `mc restart` in the parent shell never executes
- Removes the now-redundant `mc restart` and `rm -rf` lines from `startUpdate` in `app.ts`
- Adds timestamps to each line in `/tmp/moonclock-update.log` using a `date` pipe (no extra packages required)

## Test plan
- [ ] Trigger an update and confirm `/tmp/moonclock-update.log` has timestamped lines
- [ ] Confirm `/usr/local/bin/moonclock/update` is removed after a successful update

🤖 Generated with [Claude Code](https://claude.com/claude-code)