### PR TITLE
Add timestamped logging to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 
-CURRENT_DIR=$(pwd)
+LOG_FILE="/tmp/moonclock-update.log"
 DATA_FOLDER="/var/lib/moonclock"
 APP_FOLDER="/usr/local/bin/moonclock"
 
+log() {
+  echo "$1"
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
+}
+
 if [ ! -d "$DATA_FOLDER" ]; then
     sudo mkdir -p "$DATA_FOLDER"
-fi 
+fi
 
 sudo touch $DATA_FOLDER/current_install_step.txt
 sudo chmod 666 $DATA_FOLDER/current_install_step.txt
 
 message="Installing Dependencies"
-echo "$message"
+log "$message"
 echo "$message" > $DATA_FOLDER/current_install_step.txt
 
 sudo ./install-dependencies.sh
@@ -20,71 +25,70 @@ sudo ./install-dependencies.sh
 MOONCLOCK_VERSION=$(jq -r '.version' package.json)
 
 message="Installing Moonclock ($MOONCLOCK_VERSION)"
-echo "$message"
+log "$message"
 echo "$message" > $DATA_FOLDER/current_install_step.txt
 
-
-echo " -> Creating app folders"
+log " -> Creating app folders"
 
 if [ ! -d "$APP_FOLDER" ]; then
     sudo mkdir -p "$APP_FOLDER"
     sudo mkdir -p "$APP_FOLDER/releases"
     sudo mkdir -p "$APP_FOLDER/releases/$MOONCLOCK_VERSION"
 else
-    echo "   -> app folders exist, skipping"
-fi 
+    log "   -> app folders exist, skipping"
+fi
 
-echo " -> Copying app to release folder"
+log " -> Copying app to release folder"
 
 cp -r . "$APP_FOLDER/releases/$MOONCLOCK_VERSION"
 
-echo " -> Copying services to /etc/systemd/system/"
+log " -> Copying services to /etc/systemd/system/"
 
 sudo cp services/moonclock-app.service /etc/systemd/system/
 sudo cp services/moonclock-hardware.service /etc/systemd/system/
 sudo cp services/moonclock-update-checker.service /etc/systemd/system/
 sudo cp services/moonclock-update-checker.timer /etc/systemd/system/
 
-echo " -> Reloading systemd daemons"
+log " -> Reloading systemd daemons"
 
 sudo systemctl daemon-reload
 
-echo " -> Enabling services to start on restart"
+log " -> Enabling services to start on restart"
 
 sudo systemctl enable moonclock-app
 sudo systemctl enable moonclock-hardware
 sudo systemctl enable moonclock-update-checker.timer
 
-echo " -> Seeding database file"
+log " -> Seeding database file"
 
 sudo touch $DATA_FOLDER/database.json
 sudo chmod 666 $DATA_FOLDER/database.json
 
-echo " -> Loosen fontconfig cache permissions"
+log " -> Loosen fontconfig cache permissions"
 
 sudo chmod 666 /var/cache/fontconfig
 
-echo " -> Seeding custom scenes"
+log " -> Seeding custom scenes"
 
 if [ ! -d "$DATA_FOLDER/custom_scenes" ]; then
     sudo mkdir -p "$DATA_FOLDER/custom_scenes"
 else
-    echo "   -> custom scenes directory exists, skipping"
-fi 
+    log "   -> custom scenes directory exists, skipping"
+fi
 
 sudo cp "$APP_FOLDER/releases/$MOONCLOCK_VERSION/custom_scenes/"* "$DATA_FOLDER/custom_scenes/"
 
 message="Starting Moonclock"
-echo "$message"
+log "$message"
 echo "$message" > $DATA_FOLDER/current_install_step.txt
 
 sleep 5
 
-echo " -> Symlinking release to moonclock/current"
+log " -> Symlinking release to moonclock/current"
 
 sudo ln -sfn "$APP_FOLDER/releases/$MOONCLOCK_VERSION" $APP_FOLDER/current
 
-echo " -> Symlinking mc to bin/mc"
+log " -> Symlinking mc to bin/mc"
 
 sudo ln -sf "$APP_FOLDER/current/bin/mc" /usr/local/bin/mc
 

--- a/src/server/actions/app.ts
+++ b/src/server/actions/app.ts
@@ -27,7 +27,7 @@ export async function startUpdate() {
       sudo tar -xzvf ${absoluteFilePath} --strip-components=1 -C "/usr/local/bin/moonclock/update" &&
       cd /usr/local/bin/moonclock/update/ &&
       sudo ./install.sh
-    } 2>&1 | while IFS= read -r line; do echo "[$(date '+%Y-%m-%d %H:%M:%S')] $line"; done | tee /tmp/moonclock-update.log`);
+    }`);
   } catch (e) {
     console.log("Error trying to update!", e);
     return false;


### PR DESCRIPTION
## Summary
- Adds a `log()` function to `install.sh` that echoes to stdout and appends a timestamped line to `/tmp/moonclock-update.log`
- Replaces all `echo` calls in `install.sh` with `log()` so every step is recorded
- Removes the pipe-based `tee` approach from `startUpdate` — it was unreliable because systemd kills the entire service cgroup on restart, discarding buffered pipe output before `tee` could flush to disk

## Test plan
- [ ] Trigger an update and confirm `/tmp/moonclock-update.log` exists with timestamped lines after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)