### PR TITLE
Add loading bar macro for preset preview feedback

### DIFF
--- a/hardware/index.ts
+++ b/hardware/index.ts
@@ -350,7 +350,11 @@ export async function createCanvas(dimensions: Dimensions) {
               fontSize: 8,
               startingRow: 18,
             }),
-            loadingBar({ duration: previewDurationMs }),
+            loadingBar({
+              duration: previewDurationMs,
+              color: "#009900",
+              height: 1,
+            }),
           ]);
 
           await new Promise((resolve) =>

--- a/hardware/index.ts
+++ b/hardware/index.ts
@@ -2,7 +2,12 @@ import { LedMatrix, GpioMapping } from "rpi-led-matrix";
 import { checkForNewDisplayConfig } from "./checkForNewDisplayConfig";
 import { createDisplayEngine } from "../src/display-engine";
 import { Dimensions, Macro, Pixel } from "../src/display-engine/types";
-import { coordinates, marquee, text } from "../src/display-engine/marcoConfigs";
+import {
+  coordinates,
+  loadingBar,
+  marquee,
+  text,
+} from "../src/display-engine/marcoConfigs";
 import { getData, setData } from "@/server/db";
 import { getEndDate } from "@/helpers/getEndDate";
 import { transformPresetToDisplayMacros } from "@/server/actions/transformPresetToDisplayMacros";
@@ -79,7 +84,7 @@ export async function createCanvas(dimensions: Dimensions) {
     res.header("Access-Control-Allow-Methods", "GET");
     res.header(
       "Access-Control-Allow-Headers",
-      "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+      "Origin, X-Requested-With, Content-Type, Accept, Authorization",
     );
 
     // Handle preflight requests
@@ -121,7 +126,7 @@ export async function createCanvas(dimensions: Dimensions) {
   const { panel } = await getData();
 
   let displayConfig: Macro[] = await transformPresetToDisplayMacros(
-    panel.defaultPreset
+    panel.defaultPreset,
   );
   let preset: Preset = panel.defaultPreset;
   let renderedAt: string = new Date().toJSON();
@@ -145,7 +150,7 @@ export async function createCanvas(dimensions: Dimensions) {
       {
         ...LedMatrix.defaultRuntimeOptions(),
         gpioSlowdown: panel[PanelField.GpioSlowdown],
-      }
+      },
     );
     matrix.afterSync(() => {
       const pixelUpdates = updateQueue.shift();
@@ -285,7 +290,7 @@ export async function createCanvas(dimensions: Dimensions) {
       abortCurrentOperation = false;
 
       console.log(
-        "[HARDWARE] Button pressed! Cycling to next pinned preset..."
+        "[HARDWARE] Button pressed! Cycling to next pinned preset...",
       );
 
       const { presets } = getData();
@@ -309,7 +314,7 @@ export async function createCanvas(dimensions: Dimensions) {
         const nextPreset = pinnedPresets[currentPinnedIndex];
 
         console.log(
-          `[HARDWARE] Switching to preset: ${nextPreset[PresetField.Name]}`
+          `[HARDWARE] Switching to preset: ${nextPreset[PresetField.Name]}`,
         );
 
         const endDate = getEndDate(nextPreset);
@@ -320,6 +325,8 @@ export async function createCanvas(dimensions: Dimensions) {
           const minutes = endDate.getMinutes().toString().padStart(2, "0");
           const period = hours24 >= 12 ? "PM" : "AM";
           const endTimeText = `${hours12}:${minutes} ${period}`;
+
+          const previewDurationMs = 3000;
 
           engine.render([
             text({
@@ -343,9 +350,12 @@ export async function createCanvas(dimensions: Dimensions) {
               fontSize: 8,
               startingRow: 18,
             }),
+            loadingBar({ duration: previewDurationMs }),
           ]);
 
-          await new Promise((resolve) => setTimeout(resolve, 3000));
+          await new Promise((resolve) =>
+            setTimeout(resolve, previewDurationMs),
+          );
 
           if (abortCurrentOperation) {
             console.log("[HARDWARE] Operation aborted by new button press");

--- a/src/display-engine/index.ts
+++ b/src/display-engine/index.ts
@@ -20,6 +20,7 @@ import { startCustom } from "./macros/custom";
 import { startCoordinates } from "./macros/coordinates";
 import { startMoon } from "./macros/moon";
 import { startEmoji } from "./macros/emoji";
+import { startLoadingBar } from "./macros/loading-bar";
 
 export type { Pixel, Macro, MacroConfig, MacroName, Dimensions } from "./types";
 
@@ -46,6 +47,7 @@ async function startMacros({
     [MacroName.Coordinates]: startCoordinates,
     [MacroName.Moon]: startMoon,
     [MacroName.Emoji]: startEmoji,
+    [MacroName.LoadingBar]: startLoadingBar,
   };
 
   const stops = await Promise.all(
@@ -62,7 +64,7 @@ async function startMacros({
         updatePixels,
         createCanvas,
       });
-    })
+    }),
   );
 
   return () => {
@@ -133,7 +135,7 @@ export function createDisplayEngine({
               (baseColor, pixel) => {
                 return mixColors({ newColor: pixel.rgba, baseColor });
               },
-              new Uint8ClampedArray([0, 0, 0, 255])
+              new Uint8ClampedArray([0, 0, 0, 255]),
             );
 
             pixelsToUpdate.push({

--- a/src/display-engine/macros/loading-bar.ts
+++ b/src/display-engine/macros/loading-bar.ts
@@ -1,0 +1,50 @@
+import { MacroFn } from "../types";
+import { syncFromCanvas } from "../canvas";
+import { getAnimationFrame, stopAnimationFrame } from "../animation";
+
+export const startLoadingBar: MacroFn = async ({
+  macroConfig,
+  dimensions,
+  ctx,
+  index,
+  updatePixels,
+}) => {
+  const config = {
+    color: "#ffffff",
+    height: 2,
+    startingRow: dimensions.height - 2,
+    duration: 3000,
+    ...macroConfig,
+  };
+
+  let timeoutId: NodeJS.Timeout;
+  let running = true;
+  const startTime = performance.now();
+
+  function runFrame() {
+    const elapsed = performance.now() - startTime;
+    const progress = Math.min(elapsed / config.duration, 1);
+    const barWidth = Math.floor(progress * dimensions.width);
+
+    ctx.clearRect(0, 0, dimensions.width, dimensions.height);
+
+    if (barWidth > 0) {
+      ctx.fillStyle = config.color;
+      ctx.fillRect(0, config.startingRow, barWidth, config.height);
+    }
+
+    const pixels = syncFromCanvas(ctx, dimensions);
+    updatePixels(pixels, index);
+
+    if (running && progress < 1) {
+      timeoutId = getAnimationFrame(runFrame, { framesPerSecond: 20 });
+    }
+  }
+
+  runFrame();
+
+  return () => {
+    running = false;
+    stopAnimationFrame(timeoutId);
+  };
+};

--- a/src/display-engine/macros/loading-bar.ts
+++ b/src/display-engine/macros/loading-bar.ts
@@ -10,7 +10,7 @@ export const startLoadingBar: MacroFn = async ({
   updatePixels,
 }) => {
   const config = {
-    color: "#ffffff",
+    color: "#009900",
     height: 2,
     startingRow: dimensions.height - 2,
     duration: 3000,

--- a/src/display-engine/marcoConfigs.ts
+++ b/src/display-engine/marcoConfigs.ts
@@ -5,6 +5,7 @@ import {
   MacroCustomConfig,
   MacroEmojiConfig,
   MacroImageConfig,
+  MacroLoadingBarConfig,
   MacroMarqueeConfig,
   MacroMeteorsConfig,
   MacroMoonConfig,
@@ -65,8 +66,15 @@ export const moon = (macroConfig: Partial<MacroMoonConfig>): Macro => ({
 });
 
 export const coordinates = (
-  macroConfig: Partial<MacroCoordinatesConfig>
+  macroConfig: Partial<MacroCoordinatesConfig>,
 ): Macro => ({
   macroName: MacroName.Coordinates,
+  macroConfig,
+});
+
+export const loadingBar = (
+  macroConfig: Partial<MacroLoadingBarConfig>,
+): Macro => ({
+  macroName: MacroName.LoadingBar,
   macroConfig,
 });

--- a/src/display-engine/types.ts
+++ b/src/display-engine/types.ts
@@ -12,6 +12,7 @@ export enum MacroName {
   Coordinates = "coordinates",
   Moon = "moon",
   Emoji = "emoji",
+  LoadingBar = "loadingBar",
 }
 export interface Gradient {
   direction: "vertical" | "horizontal";
@@ -111,6 +112,13 @@ export interface MacroMoonConfig {
   animateStarTwinkle?: boolean;
 }
 
+export interface MacroLoadingBarConfig {
+  duration: number;
+  color: string;
+  height: number;
+  startingRow: number;
+}
+
 export type MacroConfig = MacroBoxConfig &
   MacroTextConfig &
   MacroMarqueeConfig &
@@ -121,7 +129,8 @@ export type MacroConfig = MacroBoxConfig &
   MacroCoordinatesConfig &
   MacroMoonConfig &
   MacroRippleConfig &
-  MacroEmojiConfig;
+  MacroEmojiConfig &
+  MacroLoadingBarConfig;
 
 export interface Macro {
   macroName: MacroName;
@@ -146,12 +155,12 @@ export interface AnimationConfig {
 export type UpdatePixels = (pixels: Pixel[], index: number) => void;
 export type InternalPixelsChangeCallback = (
   pixels: Pixel[],
-  index: number
+  index: number,
 ) => void;
 export type PixelsChangeCallback = (pixels: Pixel[]) => void;
 export type MacroStopCallback = () => void;
 export type CreateCanvas = (
-  dimensions: Dimensions
+  dimensions: Dimensions,
 ) => Promise<HTMLCanvasElement>;
 
 export type MacroFn = ({


### PR DESCRIPTION
## Summary
- Adds a `loadingBar` macro to the display engine that animates a bar from left to right across the bottom of the grid over a configurable `duration`
- Used during the 3-second preset preview screen so users have visual feedback while waiting for the preset to activate

## Details
The macro runs at 20fps using the existing `getAnimationFrame` animation system, growing the bar width from 0→32px proportionally to elapsed time. Defaults: `height: 2`, `startingRow: 30`, `color: "#ffffff"`, `duration: 3000`.

## Test plan
- [ ] Press the button to cycle through pinned presets and confirm the loading bar animates smoothly across the bottom 2 rows during the 3-second preview
- [ ] Confirm the bar completes just as the preset activates
- [ ] Confirm aborting mid-preview (pressing the button again) stops the bar cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)