### PR TITLE
Detach mc restart from caller cgroup during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,4 +97,4 @@ echo "" > $DATA_FOLDER/current_install_step.txt
 cd /
 sudo rm -fr /usr/local/bin/moonclock/update
 
-sudo mc restart
+sudo systemd-run --no-block --collect /usr/local/bin/mc restart


### PR DESCRIPTION
## Summary
Fixes an issue where `moonclock-hardware` was not being restarted by the install script, causing new releases to ship updated app code but stale hardware code.

## Root cause
`install.sh` is exec'd by the `moonclock-app` Next.js process (via `/api/check-for-update`), so it lives in `moonclock-app`'s systemd cgroup. The final `sudo mc restart` runs `systemctl restart moonclock-app` first, which kills the whole cgroup — including `install.sh` and its in-flight `mc restart` subprocess — before the subsequent `systemctl restart moonclock-hardware` and `systemctl restart moonclock-update-checker.timer` lines have a chance to run.

Verified on the Pi: `ActiveEnterTimestamp` for `moonclock-hardware` was nearly a month older than the last 0.82.0 install.

## Fix
Wrap the restart in `systemd-run --no-block --collect` so it runs in a fresh transient unit outside `moonclock-app`'s cgroup. The transient unit survives the cgroup teardown and finishes restarting all three services.

## Test plan
- [ ] Cut a new release and run an update from the web UI on the Pi
- [ ] Confirm `systemctl show moonclock-hardware -p ActiveEnterTimestamp` advances to the install time
- [ ] Confirm the hardware client picks up new bundle changes (e.g., loading bar from #109) without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)