### PR TITLE
Add web app manifest for iOS PWA support

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "Moon Clock",
+  "short_name": "Moon Clock",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#333333",
+  "theme_color": "#333333",
+  "icons": [
+    {
+      "src": "/app-icon.png",
+      "sizes": "770x758",
+      "type": "image/png",
+      "purpose": "any"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,12 @@ export default function RootLayout({
         />
         <link rel="icon" href="/app-icon.png" type="image/x-icon" />
         <link rel="apple-touch-icon" href="/app-icon.png" />
+        <link rel="manifest" href="/manifest.webmanifest" />
         <meta name="theme-color" content="#333333" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-title" content="Moonclock" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black" />
         <ColorSchemeScript defaultColorScheme="dark" />
       </head>
       <body>


### PR DESCRIPTION
## Summary
- Adds `public/manifest.webmanifest` with `scope: "/"` and `display: "standalone"` so iOS treats drawer link clicks as in-app navigation instead of opening Safari's in-app browser overlay (the "X" in the top-left corner).
- Wires the manifest into `layout.tsx` along with the Apple-specific PWA meta tags (`apple-mobile-web-app-capable`, `apple-mobile-web-app-title`, and a non-translucent status-bar style).

## Test plan
- [ ] Delete any existing Moon Clock home-screen icon on iOS.
- [ ] Load the site in Safari, Add to Home Screen, launch from the icon.
- [ ] Tap drawer links — they should navigate in-app with no in-app-browser overlay.
- [ ] Confirm the header (burger + title) is fully tappable and not obscured by the status bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)