### PR TITLE
Improve update flow: split check/download, add progress, relocate button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ custom_scenes/automated-test-scene-123.json
 node_modules
 moonclock
 release.tar.gz
+current_download_progress.json
 
 /dist
 

--- a/e2e/panel.spec.ts
+++ b/e2e/panel.spec.ts
@@ -48,7 +48,7 @@ test.describe("Test", () => {
 
     await page.getByTestId("preset-name").fill("Preset 123");
 
-    await page.getByRole("button", { name: "Update" }).click();
+    await page.getByRole("button", { name: "Update", exact: true }).click();
 
     await expect(page.getByText("Preset 123 until...")).toBeVisible();
   });

--- a/services/moonclock-update-checker.service
+++ b/services/moonclock-update-checker.service
@@ -7,7 +7,6 @@ User=root
 Group=root
 WorkingDirectory=/usr/local/bin/moonclock
 ExecStart=curl -X PUT -fsS http://localhost:80/api/check-for-update
-ExecStart=curl -X POST -fsS http://localhost:80/api/download-update
 
 [Install]
 WantedBy=multi-user.target

--- a/services/moonclock-update-checker.service
+++ b/services/moonclock-update-checker.service
@@ -6,7 +6,8 @@ Type=oneshot
 User=root
 Group=root
 WorkingDirectory=/usr/local/bin/moonclock
-ExecStart=curl -X PUT -v http://localhost:80/api/check-for-update
+ExecStart=curl -X PUT -fsS http://localhost:80/api/check-for-update
+ExecStart=curl -X POST -fsS http://localhost:80/api/download-update
 
 [Install]
 WantedBy=multi-user.target

--- a/src/app/api/check-for-update/route.ts
+++ b/src/app/api/check-for-update/route.ts
@@ -1,19 +1,8 @@
-import { setData } from "@/server/db";
+import { getData, setData } from "@/server/db";
 import packageInfo from "../../../../package.json";
-import { log } from "console";
-import { pipeline, Readable } from "stream";
-import { exec } from "child_process";
-import { promisify } from "util";
-import fs from "fs";
-
-const pipelineAsync = promisify(pipeline);
-const execPromise = promisify(exec);
+import { releaseDownloadPath } from "@/server/utils";
 
 export async function PUT() {
-  let message: string = "";
-
-  log("Checking for update");
-
   try {
     const url = `https://api.github.com/repos/roykolak/moonclock/releases`;
     const releases = await fetch(url).then((response) => response.json());
@@ -21,65 +10,45 @@ export async function PUT() {
     const latestRelease = releases[0];
 
     if (!latestRelease) {
-      const message = "No release found.";
-      console.log(message);
-      return Response.json({ message });
+      return Response.json({ message: "No release found.", available: false });
     }
 
     const asset = latestRelease.assets[0];
 
     if (!asset) {
-      const message = "No asset found.";
-      console.log(message);
-      return Response.json({ message });
+      return Response.json({ message: "No asset found.", available: false });
     }
 
     const latestVersion = latestRelease.tag_name.replace("v", "");
 
     if (latestVersion === packageInfo.version) {
-      const message = "Up to date.";
-      console.log(message);
-      return Response.json({ message });
+      const { nextVersion } = getData();
+      if (nextVersion) setData({ nextVersion: null });
+      return Response.json({ message: "Up to date.", available: false });
     }
-
-    const downloadUrl = asset.browser_download_url;
-    const fileName = asset.name;
-
-    console.log(`Downloading ${fileName} from ${downloadUrl}...`);
-
-    const assetResponse = await fetch(downloadUrl);
-    if (!assetResponse.ok) {
-      throw new Error(`Failed to download asset: ${assetResponse.status}`);
-    }
-
-    const readableStream = Readable.fromWeb(assetResponse.body as any);
-
-    const savePath = "/usr/local/bin/moonclock/release.tar.gz";
-
-    await execPromise(`rm -f ${savePath}`);
-
-    const fileStream = fs.createWriteStream(savePath);
-    await pipelineAsync(readableStream, fileStream);
-
-    console.log(`Downloaded and saved as ${savePath}, ${latestVersion}`);
 
     setData({
       nextVersion: {
         version: latestVersion,
         releaseNotes: latestRelease.body,
+        downloadUrl: asset.browser_download_url,
+        absoluteFilePath: releaseDownloadPath(),
+        downloadedAt: null,
         updateFinishedAt: null,
         updateStartedAt: null,
-        absoluteFilePath: savePath,
       },
     });
 
-    message = "Update available - " + latestVersion;
+    return Response.json({
+      message: `Update available - ${latestVersion}`,
+      available: true,
+      version: latestVersion,
+    });
   } catch (e) {
-    log(e);
-    message = "Error checking for update";
+    console.log(e);
+    return Response.json({
+      message: "Error checking for update",
+      available: false,
+    });
   }
-
-  log(message);
-
-  return Response.json({ message });
 }

--- a/src/app/api/current-download-progress/route.ts
+++ b/src/app/api/current-download-progress/route.ts
@@ -1,0 +1,11 @@
+import { currentDownloadProgressFile } from "@/server/utils";
+import fs from "fs";
+
+export async function GET() {
+  try {
+    const raw = fs.readFileSync(currentDownloadProgressFile(), "utf-8");
+    return Response.json(JSON.parse(raw));
+  } catch {
+    return Response.json(null);
+  }
+}

--- a/src/app/api/download-update/route.ts
+++ b/src/app/api/download-update/route.ts
@@ -1,0 +1,140 @@
+import { getData, setData } from "@/server/db";
+import {
+  currentDownloadProgressFile,
+  releaseDownloadPath,
+} from "@/server/utils";
+import fs from "fs";
+import { pipeline, Readable, Transform } from "stream";
+import { promisify } from "util";
+
+const pipelineAsync = promisify(pipeline);
+
+function writeProgress(progress: {
+  version: string;
+  status: "downloading" | "complete" | "error";
+  bytesDownloaded: number;
+  totalBytes: number;
+  message?: string;
+}) {
+  fs.writeFileSync(currentDownloadProgressFile(), JSON.stringify(progress), {
+    mode: 0o666,
+  });
+}
+
+function readProgress() {
+  try {
+    return JSON.parse(fs.readFileSync(currentDownloadProgressFile(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+async function runDownload(version: string, downloadUrl: string) {
+  try {
+    writeProgress({
+      version,
+      status: "downloading",
+      bytesDownloaded: 0,
+      totalBytes: 0,
+    });
+
+    const response = await fetch(downloadUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to download asset: ${response.status}`);
+    }
+
+    const totalBytes = Number(response.headers.get("content-length") || 0);
+    let bytesDownloaded = 0;
+    let lastWriteAt = 0;
+
+    const tracker = new Transform({
+      transform(chunk, _enc, cb) {
+        bytesDownloaded += chunk.length;
+        const now = Date.now();
+        if (now - lastWriteAt > 250) {
+          lastWriteAt = now;
+          writeProgress({
+            version,
+            status: "downloading",
+            bytesDownloaded,
+            totalBytes,
+          });
+        }
+        cb(null, chunk);
+      },
+    });
+
+    const savePath = releaseDownloadPath();
+    fs.rmSync(savePath, { force: true });
+
+    await pipelineAsync(
+      Readable.fromWeb(response.body as any),
+      tracker,
+      fs.createWriteStream(savePath),
+    );
+
+    writeProgress({
+      version,
+      status: "complete",
+      bytesDownloaded,
+      totalBytes: totalBytes || bytesDownloaded,
+    });
+
+    const { nextVersion } = getData();
+    if (nextVersion?.version === version) {
+      setData({
+        nextVersion: { ...nextVersion, downloadedAt: new Date().toJSON() },
+      });
+    }
+  } catch (e) {
+    console.log("Download failed", e);
+    writeProgress({
+      version,
+      status: "error",
+      bytesDownloaded: 0,
+      totalBytes: 0,
+      message: e instanceof Error ? e.message : String(e),
+    });
+  }
+}
+
+export async function POST() {
+  const { nextVersion } = getData();
+
+  if (!nextVersion) {
+    return Response.json({ status: "no-update" });
+  }
+
+  if (nextVersion.downloadedAt && fs.existsSync(nextVersion.absoluteFilePath)) {
+    writeProgress({
+      version: nextVersion.version,
+      status: "complete",
+      bytesDownloaded: 0,
+      totalBytes: 0,
+    });
+    return Response.json({ status: "already-downloaded" });
+  }
+
+  if (!nextVersion.downloadUrl) {
+    writeProgress({
+      version: nextVersion.version,
+      status: "error",
+      bytesDownloaded: 0,
+      totalBytes: 0,
+      message: "Stale update record — please check for update again.",
+    });
+    return Response.json({ status: "stale" });
+  }
+
+  const progress = readProgress();
+  if (
+    progress?.status === "downloading" &&
+    progress.version === nextVersion.version
+  ) {
+    return Response.json({ status: "in-progress" });
+  }
+
+  void runDownload(nextVersion.version, nextVersion.downloadUrl);
+
+  return Response.json({ status: "started" });
+}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6,18 +6,23 @@ import {
   AppShell,
   Box,
   Burger,
+  Button,
   Divider,
   Group,
   NavLink,
   Text,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { showNotification } from "@mantine/notifications";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 import {
   IconAdjustmentsHorizontal,
   IconCpu,
   IconDeviceTv,
   IconExclamationCircleFilled,
   IconLayersIntersect,
+  IconRefresh,
   IconSpray,
 } from "@tabler/icons-react";
 import Link from "next/link";
@@ -35,8 +40,32 @@ function App({
   nextVersion: NextVersion | null;
 }) {
   const [navOpened, { toggle: toggleNav }] = useDisclosure();
+  const [checkingForUpdate, setCheckingForUpdate] = useState(false);
+  const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
 
   const pathname = usePathname();
+  const router = useRouter();
+
+  const handleCheckForUpdate = async () => {
+    setCheckingForUpdate(true);
+    try {
+      const response = await fetch("/api/check-for-update", { method: "PUT" });
+      const data = await response.json();
+      if (data.available) {
+        router.refresh();
+        setReleaseNotesOpen(true);
+      } else if (data.message?.includes("Error")) {
+        showNotification({ message: data.message, color: "red" });
+      }
+    } catch {
+      showNotification({
+        message: "Failed to check for update",
+        color: "red",
+      });
+    } finally {
+      setCheckingForUpdate(false);
+    }
+  };
 
   return (
     <AppShell
@@ -58,7 +87,11 @@ function App({
             data-testid="app-menu"
           />
           <Text flex={1}>Moon Clock</Text>
-          <UpdatePrompt nextVersion={nextVersion} />
+          <UpdatePrompt
+            nextVersion={nextVersion}
+            releaseNotesOpen={releaseNotesOpen}
+            onReleaseNotesOpenChange={setReleaseNotesOpen}
+          />
         </Group>
       </AppShell.Header>
       <AppShell.Navbar p="md">
@@ -130,7 +163,22 @@ function App({
         />
 
         <Box flex="auto"></Box>
-        <Text c="dimmed">{packageInfo.version}</Text>
+        <Group justify="space-between" align="center">
+          <Text c="dimmed" size="sm">
+            v{packageInfo.version}
+          </Text>
+          <Button
+            size="compact-xs"
+            variant="subtle"
+            color="gray"
+            leftSection={<IconRefresh size={14} stroke={1.5} />}
+            onClick={handleCheckForUpdate}
+            loading={checkingForUpdate}
+            data-testid="check-for-update-button"
+          >
+            Check for updates
+          </Button>
+        </Group>
       </AppShell.Navbar>
       <AppShell.Main>
         <ErrorBoundary

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -29,24 +29,6 @@ export function Settings({ panel, customSceneNames }: SettingsProps) {
     },
   });
 
-  const handleCheckForUpdate = async () => {
-    try {
-      const response = await fetch("/api/check-for-update", {
-        method: "PUT",
-      });
-      const data = await response.json();
-      showNotification({
-        message: data.message || "Update check completed",
-        color: data.message?.includes("Error") ? "red" : "blue",
-      });
-    } catch {
-      showNotification({
-        message: "Failed to check for update",
-        color: "red",
-      });
-    }
-  };
-
   return (
     <form
       onSubmit={form.onSubmit((values) => {
@@ -210,15 +192,6 @@ export function Settings({ panel, customSceneNames }: SettingsProps) {
         </Accordion>
         <Button type="submit" fullWidth mt="md">
           Save
-        </Button>
-        <Button
-          onClick={handleCheckForUpdate}
-          fullWidth
-          mt="md"
-          variant="light"
-          data-testid="check-for-update-button"
-        >
-          Check for Update
         </Button>
       </Stack>
     </form>

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -2,27 +2,65 @@
 
 import { markAsUpdated, startUpdate } from "@/server/actions/app";
 import { NextVersion } from "@/types";
-import { Button, Code, Flex, Loader, Modal, Stack, Text } from "@mantine/core";
+import {
+  Button,
+  Code,
+  Flex,
+  Loader,
+  Modal,
+  Progress,
+  Stack,
+  Text,
+} from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface SettingsProps {
   nextVersion: NextVersion | null;
+  releaseNotesOpen: boolean;
+  onReleaseNotesOpenChange: (open: boolean) => void;
 }
 
-export function UpdatePrompt({ nextVersion }: SettingsProps) {
+type Phase = "downloading" | "installing";
+
+interface DownloadProgress {
+  version: string;
+  status: "downloading" | "complete" | "error";
+  bytesDownloaded: number;
+  totalBytes: number;
+  message?: string;
+}
+
+function formatMB(bytes: number) {
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function UpdatePrompt({
+  nextVersion,
+  releaseNotesOpen,
+  onReleaseNotesOpenChange,
+}: SettingsProps) {
   const [updatingModalOpened, updatingModalHandler] = useDisclosure(false);
-  const [releaseNotesModalOpened, releaseNotesModalHandler] =
-    useDisclosure(false);
-  const [currentInstallStep, setCurrentInstallStep] = useState();
+  const [phase, setPhase] = useState<Phase>("downloading");
+  const [downloadProgress, setDownloadProgress] =
+    useState<DownloadProgress | null>(null);
+  const [currentInstallStep, setCurrentInstallStep] = useState<string>("");
+  const installStartedRef = useRef(false);
 
   useEffect(() => {
     if (!updatingModalOpened) return;
 
-    (async () => {
+    let cancelled = false;
+    installStartedRef.current = false;
+
+    const beginInstall = async () => {
+      if (installStartedRef.current) return;
+      installStartedRef.current = true;
+      setPhase("installing");
       await startUpdate();
 
       const loop = setInterval(async () => {
+        if (cancelled) return clearInterval(loop);
         const response = await fetch(`/api/current-install-step`);
         const data = await response.json();
         setCurrentInstallStep(data.step);
@@ -30,13 +68,41 @@ export function UpdatePrompt({ nextVersion }: SettingsProps) {
         if (data.step.includes("Starting")) {
           markAsUpdated();
           clearInterval(loop);
-          setTimeout(() => {
-            window.location.reload();
-          }, 10000);
+          setTimeout(() => window.location.reload(), 10000);
         }
       }, 1000);
-    })();
-  }, [updatingModalOpened]);
+    };
+
+    const beginDownload = async () => {
+      if (nextVersion?.downloadedAt) {
+        beginInstall();
+        return;
+      }
+
+      setPhase("downloading");
+      await fetch(`/api/download-update`, { method: "POST" });
+
+      const loop = setInterval(async () => {
+        if (cancelled) return clearInterval(loop);
+        const response = await fetch(`/api/current-download-progress`);
+        const data: DownloadProgress | null = await response.json();
+        setDownloadProgress(data);
+
+        if (data?.status === "complete") {
+          clearInterval(loop);
+          beginInstall();
+        } else if (data?.status === "error") {
+          clearInterval(loop);
+        }
+      }, 500);
+    };
+
+    beginDownload();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [updatingModalOpened, nextVersion?.downloadedAt]);
 
   useEffect(() => {
     if (nextVersion?.updateStartedAt && !nextVersion?.updateFinishedAt) {
@@ -46,15 +112,18 @@ export function UpdatePrompt({ nextVersion }: SettingsProps) {
 
   if (!nextVersion) return;
 
+  const downloadPct =
+    downloadProgress && downloadProgress.totalBytes > 0
+      ? (downloadProgress.bytesDownloaded / downloadProgress.totalBytes) * 100
+      : 0;
+
   return (
     <>
       {!nextVersion.updateStartedAt && (
         <Button
           size="xs"
           variant="outline"
-          onClick={async () => {
-            releaseNotesModalHandler.open();
-          }}
+          onClick={() => onReleaseNotesOpenChange(true)}
         >
           Update...
         </Button>
@@ -62,8 +131,8 @@ export function UpdatePrompt({ nextVersion }: SettingsProps) {
 
       <Modal
         title={`What's new in v${nextVersion?.version}`}
-        opened={releaseNotesModalOpened}
-        onClose={releaseNotesModalHandler.close}
+        opened={releaseNotesOpen}
+        onClose={() => onReleaseNotesOpenChange(false)}
       >
         <Stack gap="xl">
           <Code style={{ whiteSpace: "pre-line" }}>
@@ -71,8 +140,8 @@ export function UpdatePrompt({ nextVersion }: SettingsProps) {
           </Code>
           <Stack>
             <Button
-              onClick={async () => {
-                releaseNotesModalHandler.close();
+              onClick={() => {
+                onReleaseNotesOpenChange(false);
                 updatingModalHandler.open();
               }}
             >
@@ -95,9 +164,35 @@ export function UpdatePrompt({ nextVersion }: SettingsProps) {
           p={10}
           mih={400}
         >
-          <Loader size="xl" />
-          <Text size="lg">Update in Progress</Text>
-          <Text size="sm">{currentInstallStep}</Text>
+          {phase === "downloading" ? (
+            <>
+              <Text size="lg">Downloading v{nextVersion.version}</Text>
+              {downloadProgress?.status === "error" ? (
+                <Text size="sm" c="red">
+                  {downloadProgress.message || "Download failed"}
+                </Text>
+              ) : (
+                <>
+                  <Progress
+                    value={downloadPct}
+                    w="100%"
+                    animated={downloadProgress?.status !== "complete"}
+                  />
+                  <Text size="sm" c="dimmed">
+                    {downloadProgress && downloadProgress.totalBytes > 0
+                      ? `${formatMB(downloadProgress.bytesDownloaded)} / ${formatMB(downloadProgress.totalBytes)}`
+                      : "Starting download..."}
+                  </Text>
+                </>
+              )}
+            </>
+          ) : (
+            <>
+              <Loader size="xl" />
+              <Text size="lg">Update in Progress</Text>
+              <Text size="sm">{currentInstallStep}</Text>
+            </>
+          )}
         </Flex>
       </Modal>
     </>

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -26,3 +26,15 @@ export function currentInstallStepFile() {
     ? "/var/lib/moonclock/current_install_step.txt"
     : "./current_install_step.txt";
 }
+
+export function currentDownloadProgressFile() {
+  return process.env.NODE_ENV === "production"
+    ? "/var/lib/moonclock/current_download_progress.json"
+    : "./current_download_progress.json";
+}
+
+export function releaseDownloadPath() {
+  return process.env.NODE_ENV === "production"
+    ? "/usr/local/bin/moonclock/release.tar.gz"
+    : "./release.tar.gz";
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,8 @@ export interface NextVersion {
   updateStartedAt: string | null;
   updateFinishedAt: string | null;
   absoluteFilePath: string;
+  downloadUrl: string;
+  downloadedAt: string | null;
 }
 
 export interface Panel {


### PR DESCRIPTION
## Summary
- **Split the API.** `PUT /api/check-for-update` is now check-only (sub-second). New `POST /api/download-update` backgrounds the tarball download, writes byte-progress to `current_download_progress.json`, is idempotent, and skips re-downloading when the asset for `nextVersion` is already on disk. New `GET /api/current-download-progress` for polling.
- **Daily systemd timer** now chains check → download, so the tarball is typically already on disk by the time a user clicks Update.
- **UpdatePrompt** got a download phase with a real progress bar (`X.X MB / Y.Y MB`) before transitioning to the existing install phase. Pre-downloaded? Jumps straight to install.
- **Button moved.** "Check for updates" left the Settings form and now lives in the navbar footer next to the version label (compact subtle button with refresh icon). On finding an update it pops the release-notes modal directly; on "up to date" it's silent; on error it notifies.
- **Dev ergonomics.** `releaseDownloadPath()` is dev-aware so the flow can be exercised against a local server.
- Migration guard: download endpoint handles pre-existing `nextVersion` records that lack `downloadUrl` by returning an error message instead of crashing.

## Test plan
- [ ] Temporarily set `package.json` `"version"` to a value lower than the latest GitHub release; restart `npm run start:dev`.
- [ ] Click "Check for updates" in the navbar footer — button shows loading, release-notes modal pops automatically when available; silent when up-to-date.
- [ ] In the release-notes modal, click "Update Now!" — download phase shows a progress bar moving from 0 to the asset size, then transitions to the install phase.
- [ ] Re-trigger Update Now! after a successful download — should jump straight to install (skips download).
- [ ] While a download is running, hit `POST /api/download-update` again with curl — returns `{"status":"in-progress"}` and no second download starts.
- [ ] Verify on a real Pi: full check → download → install path end-to-end.
- [ ] Verify the systemd timer still works: `sudo systemctl start moonclock-update-checker.service` then check that `nextVersion.downloadedAt` and the tarball both appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)