### PR TITLE
Fix rpi-led-matrix.node require path in bundled hardware output

### DIFF
--- a/build.js
+++ b/build.js
@@ -23,15 +23,18 @@ await esbuild.build({
 
 console.log("\n -> Hardware script built");
 
-// update canvas.node path in hardware output
+// rewrite hardcoded native module paths to match where build.js
+// copies them under dist/hardware/
 const filePath = "dist/hardware/index.cjs";
 let content = fs.readFileSync(filePath, "utf8");
-const oldString = "../skia.node";
-const newString = "./skia.node";
-content = content.replace(oldString, newString);
+content = content.replace(/"\.\.\/skia\.node"/g, '"./skia.node"');
+content = content.replace(
+  /"\.\.\/build\/Release\/rpi-led-matrix\.node"/g,
+  '"./build/rpi-led-matrix.node"',
+);
 fs.writeFileSync(filePath, content, "utf8");
 
-console.log("\n -> canvas.node dependency path rewritten");
+console.log("\n -> Native module dependency paths rewritten");
 
 fs.cpSync("hardware/prebuilt", "dist/hardware", { recursive: true });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moonclock",
-  "version": "0.83.0",
+  "version": "0.84.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moonclock",
-      "version": "0.83.0",
+      "version": "0.84.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.65.0",
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moonclock",
-  "version": "0.83.0",
+  "version": "0.84.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
Hardware service crashes on boot with `Cannot find module '../build/Release/rpi-led-matrix.node'` because esbuild leaves the hardcoded require string from `rpi-led-matrix` as-is (the `.node` loader is configured external), but `build.js` copies the prebuilt binary to `dist/hardware/build/rpi-led-matrix.node`. The bundle's relative path resolves to a nonexistent `dist/build/Release/...` location.

This mirrors the existing `skia.node` rewrite already in `build.js`, adding a parallel one for `rpi-led-matrix.node`.

Likely regressed when `rpi-led-matrix` switched from `bindings()` (search-based and tolerant of layout) to a hardcoded `createRequire(import.meta.url)(...)` path. `epoll` still uses `bindings()`, which is why only `rpi-led-matrix` was broken.

## Test plan
- [x] `npm run build` succeeds
- [x] `grep "rpi-led-matrix.node" dist/hardware/index.cjs` shows the rewritten `./build/rpi-led-matrix.node` path at both require sites
- [x] `dist/hardware/build/rpi-led-matrix.node` exists at the path the bundle now looks for
- [ ] Install release on a Pi and confirm `moonclock-hardware` starts cleanly (no MODULE_NOT_FOUND in `journalctl -u moonclock-hardware`)
- [ ] Hardware page in the UI shows the connected state instead of "Hardware not connected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)