### PR TITLE
Add npm run release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ sudo npm run start:dev
 npm run build
 ```
 
+## Publishing a release
+
+`npm run release` bumps the version, builds the tarball, pushes the commit and tag, and creates the GitHub release with auto-generated notes.
+
+```
+npm run release             # patch bump (default)
+npm run release minor
+npm run release major
+npm run release 0.87.5      # specific version
+```
+
+Requires a clean working tree on `main` and an authenticated `gh` CLI (`gh auth status`). If the build or push fails, the local commit and tag are rolled back automatically. If the GitHub release step fails after the push, the script prints the commands needed to clean up the remote tag.
+
 ## Developing on a pi
 
 ```

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+BUMP="${1:-patch}"
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Working tree has uncommitted changes. Aborting." >&2
+  exit 1
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" != "main" ]; then
+  echo "Not on main (on $BRANCH). Aborting." >&2
+  exit 1
+fi
+
+git pull --ff-only
+
+NEW_VERSION=$(npm version "$BUMP")
+echo "Bumped to $NEW_VERSION"
+
+rollback_local() {
+  echo ""
+  echo "Failed. Rolling back local commit and tag for $NEW_VERSION..." >&2
+  git tag -d "$NEW_VERSION" >/dev/null 2>&1 || true
+  git reset --hard HEAD~1 >/dev/null 2>&1 || true
+}
+trap rollback_local ERR
+
+npm run build
+git push --follow-tags
+
+trap - ERR
+
+if ! gh release create "$NEW_VERSION" release.tar.gz --generate-notes --verify-tag; then
+  echo "" >&2
+  echo "Release creation failed but commit and tag were already pushed." >&2
+  echo "To clean up the remote tag and commit:" >&2
+  echo "  git push --delete origin $NEW_VERSION" >&2
+  echo "  git tag -d $NEW_VERSION" >&2
+  echo "  git reset --hard HEAD~1 && git push --force-with-lease origin main" >&2
+  exit 1
+fi
+
+echo ""
+echo "Released $NEW_VERSION"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start:dev": "concurrently \"npm run app:dev\" \"npm run hardware:dev\"",
     "test:e2e": "playwright test",
     "test:e2e:debug": "PWDEBUG=1 playwright test",
-    "test": "APP_ENV=test tsx --test"
+    "test": "APP_ENV=test tsx --test",
+    "release": "bin/release.sh"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.65.0",


### PR DESCRIPTION
## Summary
Wraps the existing manual release flow into one command. Replaces the multi-step "bump version → build → push → upload tarball → write release notes" ritual.

Usage:
```sh
npm run release             # patch bump (default)
npm run release minor
npm run release major
npm run release 0.87.5      # specific version
```

The script:
1. Refuses to run if working tree is dirty or you're not on `main`.
2. `git pull --ff-only` to make sure you're current.
3. `npm version <bump>` — bumps `package.json` + `package-lock.json`, commits with the version as message, tags `v<version>`. Matches the existing release pattern.
4. `npm run build` to produce `release.tar.gz`.
5. `git push --follow-tags`.
6. `gh release create <tag> release.tar.gz --generate-notes --verify-tag` — auto-generated notes match the existing release format.

## Rollback behavior
- Failure before push (e.g. `npm run build` fails): local commit and tag are auto-deleted, working tree restored.
- Failure after push (e.g. `gh release create` fails): prints the cleanup commands instead of running destructive force-push automatically.

## Test plan
- [ ] Dry-run on a throwaway branch / non-main branch — should refuse to run.
- [ ] Dry-run with a dirty working tree — should refuse to run.
- [ ] Run `npm run release patch` from clean main: verify version bumped, release.tar.gz built, commit + tag pushed, GitHub release created with auto-generated notes and tarball attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)