### PR TITLE
Prune old releases during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,11 @@ sudo ./install-dependencies.sh
 
 MOONCLOCK_VERSION=$(jq -r '.version' package.json)
 
+PREVIOUS_VERSION=""
+if [ -L "$APP_FOLDER/current" ]; then
+  PREVIOUS_VERSION=$(basename "$(readlink "$APP_FOLDER/current")")
+fi
+
 message="Installing Moonclock ($MOONCLOCK_VERSION)"
 log "$message"
 echo "$message" > $DATA_FOLDER/current_install_step.txt
@@ -92,9 +97,20 @@ log " -> Symlinking mc to bin/mc"
 
 sudo ln -sf "$APP_FOLDER/current/bin/mc" /usr/local/bin/mc
 
+log " -> Pruning old releases (keeping $MOONCLOCK_VERSION${PREVIOUS_VERSION:+ + $PREVIOUS_VERSION for rollback})"
+
+for d in "$APP_FOLDER/releases"/*/; do
+  v=$(basename "$d")
+  if [ "$v" != "$MOONCLOCK_VERSION" ] && [ "$v" != "$PREVIOUS_VERSION" ]; then
+    log "   -> Removing $v"
+    sudo rm -rf "$d"
+  fi
+done
+
 echo "" > $DATA_FOLDER/current_install_step.txt
 
 cd /
 sudo rm -fr /usr/local/bin/moonclock/update
+sudo rm -f /usr/local/bin/moonclock/release.tar.gz
 
 sudo systemd-run --no-block --collect /usr/local/bin/mc restart


### PR DESCRIPTION
## Summary
`install.sh` copied each release into `releases/<version>/` (~70-200MB) but never deleted old ones. After ~20 upgrades on a Pi with a small SD card, the disk filled to 100%, causing `database.json` writes to fail with `ENOSPC`, corrupting state, and bricking the hardware service mid-render. This PR adds the cleanup that should've been there from day one.

## Behavior
- Captures the existing `current` symlink target as `PREVIOUS_VERSION` *before* the symlink is swapped to the new release.
- After the install finishes, iterates `releases/*/` and deletes anything that isn't `$MOONCLOCK_VERSION` (just installed) or `$PREVIOUS_VERSION` (kept for manual rollback).
- Also drops the staged `release.tar.gz` once it's extracted — saves another ~24MB per install.

## Edge cases
- Fresh install (no `current` symlink yet): `PREVIOUS_VERSION` is empty, only the newly-installed version is kept.
- Reinstalling the same version: both checks pass for that dir, so it's preserved.
- `rm` failures don't abort the install (script doesn't `set -e`).

## Test plan
- [ ] Install on a Pi with multiple existing release dirs. Confirm post-install only the new + previous remain, and `release.tar.gz` is gone.
- [ ] Fresh install (clean Pi). Confirm only the new release dir exists, no errors about a missing `current` symlink.
- [ ] Disk usage drops back to a sustainable level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)