### PR TITLE
Fix skia-canvas downcast crash by keeping canvas alive

### DIFF
--- a/src/display-engine/canvas.ts
+++ b/src/display-engine/canvas.ts
@@ -2,34 +2,24 @@ import { Dimensions, Pixel } from "./types";
 
 export function syncFromCanvas(
   ctx: CanvasRenderingContext2D,
-  dimensions: Dimensions
+  dimensions: Dimensions,
 ) {
   const pixels: Pixel[] = [];
+  const { data } = ctx.getImageData(0, 0, dimensions.width, dimensions.height);
 
-  let data: Uint8ClampedArray | null;
-
-  try {
-    ({ data } = ctx.getImageData(0, 0, dimensions.width, dimensions.height));
-  } catch (e) {
-    console.log(e);
-    data = null;
-  }
-
-  if (data) {
-    for (let y = 0; y < dimensions.height; y++) {
-      for (let x = 0; x < dimensions.width; x++) {
-        const i = (y * dimensions.width + x) * 4;
-        pixels.push({
-          x: x,
-          y: y,
-          rgba: new Uint8ClampedArray([
-            data[i],
-            data[i + 1],
-            data[i + 2],
-            data[i + 3],
-          ]),
-        });
-      }
+  for (let y = 0; y < dimensions.height; y++) {
+    for (let x = 0; x < dimensions.width; x++) {
+      const i = (y * dimensions.width + x) * 4;
+      pixels.push({
+        x: x,
+        y: y,
+        rgba: new Uint8ClampedArray([
+          data[i],
+          data[i + 1],
+          data[i + 2],
+          data[i + 3],
+        ]),
+      });
     }
   }
 

--- a/src/display-engine/index.ts
+++ b/src/display-engine/index.ts
@@ -67,6 +67,9 @@ async function startMacros({
 
       return () => {
         stop();
+        // skia-canvas's context only holds a WeakRef to its canvas, so we
+        // must keep `canvas` reachable for the macro's lifetime — otherwise
+        // GC frees it and getImageData fails with a Neon downcast error.
         void canvas;
       };
     }),

--- a/src/display-engine/index.ts
+++ b/src/display-engine/index.ts
@@ -56,7 +56,7 @@ async function startMacros({
       const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
       const macroFn = MacroMap[macroName];
 
-      return macroFn({
+      const stop = await macroFn({
         macroConfig,
         dimensions,
         ctx,
@@ -64,6 +64,11 @@ async function startMacros({
         updatePixels,
         createCanvas,
       });
+
+      return () => {
+        stop();
+        void canvas;
+      };
     }),
   );
 


### PR DESCRIPTION
## Summary
- Each macro received only its 2D context, so the parent `Canvas` became GC-eligible the moment the `startMacros` map callback resolved. Once V8 collected it, skia-canvas's Neon `JsBox<RefCell<Canvas>>` was finalized and the next `getImageData` call failed with `failed to downcast any to JsBox<RefCell<Canvas>>`. The loading bar surfaced this most clearly — it ticked at 20fps and froze a few frames in once GC ran.
- Capture `canvas` in the returned stop closure so it stays reachable for the macro's lifetime, then releases naturally when `stopMacros()` is called.
- Drop the `try/catch` in `syncFromCanvas` that was silently swallowing the error and turning a crash into a visible freeze.

## Test plan
- [ ] Run the loading bar (button-press preset preview) and confirm it animates to completion without `failed to downcast` errors in `mc logs`.
- [ ] Cycle presets repeatedly to exercise `stopMacros` and confirm no leaked canvases or memory growth over a few minutes.
- [ ] Confirm marquee/text/meteors/image macros (anything calling `syncFromCanvas` on a long timer) still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)