### PR TITLE
Add bundled rpi-led-matrix smoke test

### DIFF
--- a/build.js
+++ b/build.js
@@ -9,8 +9,7 @@ const writeFile = promisify(fs.writeFile);
 
 console.log("Building version:", packageInfo.version);
 
-await esbuild.build({
-  entryPoints: ["hardware/index.ts"],
+const esbuildOptions = {
   bundle: true,
   platform: "node",
   loader: {
@@ -18,23 +17,39 @@ await esbuild.build({
   },
   keepNames: true,
   external: ["*.node"],
-  outfile: "dist/hardware/index.cjs",
-});
-
-console.log("\n -> Hardware script built");
+};
 
 // rewrite hardcoded native module paths to match where build.js
 // copies them under dist/hardware/
-const filePath = "dist/hardware/index.cjs";
-let content = fs.readFileSync(filePath, "utf8");
-content = content.replace(/"\.\.\/skia\.node"/g, '"./skia.node"');
-content = content.replace(
-  /"\.\.\/build\/Release\/rpi-led-matrix\.node"/g,
-  '"./build/rpi-led-matrix.node"',
-);
-fs.writeFileSync(filePath, content, "utf8");
+function rewriteNativeModulePaths(filePath) {
+  let content = fs.readFileSync(filePath, "utf8");
+  content = content.replace(/"\.\.\/skia\.node"/g, '"./skia.node"');
+  content = content.replace(
+    /"\.\.\/build\/Release\/rpi-led-matrix\.node"/g,
+    '"./build/rpi-led-matrix.node"',
+  );
+  fs.writeFileSync(filePath, content, "utf8");
+}
 
-console.log("\n -> Native module dependency paths rewritten");
+await esbuild.build({
+  ...esbuildOptions,
+  entryPoints: ["hardware/index.ts"],
+  outfile: "dist/hardware/index.cjs",
+});
+rewriteNativeModulePaths("dist/hardware/index.cjs");
+
+console.log("\n -> Hardware script built");
+
+// standalone rpi-led-matrix smoke test, bundled so it reuses the prebuilt
+// native module shipped alongside the hardware script in dist/hardware/
+await esbuild.build({
+  ...esbuildOptions,
+  entryPoints: ["hardware/test-matrix.ts"],
+  outfile: "dist/hardware/test-matrix.cjs",
+});
+rewriteNativeModulePaths("dist/hardware/test-matrix.cjs");
+
+console.log("\n -> Smoke test script built");
 
 fs.cpSync("hardware/prebuilt", "dist/hardware", { recursive: true });
 

--- a/hardware/test-matrix.ts
+++ b/hardware/test-matrix.ts
@@ -1,0 +1,117 @@
+// Standalone rpi-led-matrix smoke test.
+//
+// build.js bundles this to dist/hardware/test-matrix.cjs, next to the prebuilt
+// rpi-led-matrix.node. Run it on the Pi from a deployed release's hardware dir:
+//   cd /usr/local/bin/moonclock/current/dist/hardware
+//   sudo node test-matrix.cjs
+//
+// Options (all optional, --key=value form; flags survive sudo, env vars do not):
+//   --rows=32 --cols=32 --chain=1 --mapping=AdafruitHat --slowdown=4
+//   --panel='{"pwmBits":11,"pwnLsbNanoseconds":130,"gpioSlowdown":4,"brightness":50}'
+// --mapping is a GpioMapping key (e.g. Regular, AdafruitHat, AdafruitHatPwm).
+// --panel takes the panel JSON from the DB; individual flags override its fields.
+//
+// Ctrl+C to quit. The matrix lib needs root for GPIO, hence sudo.
+
+import {
+  LedMatrix,
+  GpioMapping,
+  type MatrixOptions,
+  type RuntimeOptions,
+} from "rpi-led-matrix";
+import type { Panel } from "@/types";
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const arg of argv) {
+    const match = arg.match(/^--([^=]+)=(.*)$/);
+    if (match) out[match[1]] = match[2];
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+let panel: Partial<Panel> = {};
+if (args.panel !== undefined) {
+  try {
+    panel = JSON.parse(args.panel);
+  } catch (e) {
+    console.error(`--panel must be valid JSON: ${(e as Error).message}`);
+    process.exit(1);
+  }
+}
+
+const rows = Number(args.rows ?? 32) as MatrixOptions["rows"];
+const cols = Number(args.cols ?? 32) as MatrixOptions["cols"];
+const chainLength = Number(args.chain ?? 1) as MatrixOptions["chainLength"];
+const gpioSlowdown = Number(
+  args.slowdown ?? panel.gpioSlowdown ?? 4,
+) as RuntimeOptions["gpioSlowdown"];
+const brightness = Number(args.brightness ?? panel.brightness ?? 50);
+const mappingKey = args.mapping ?? "AdafruitHat";
+
+const hardwareMapping = GpioMapping[mappingKey as keyof typeof GpioMapping];
+if (hardwareMapping === undefined) {
+  console.error(
+    `Unknown --mapping=${mappingKey}. Valid keys: ${Object.keys(GpioMapping).join(", ")}`,
+  );
+  process.exit(1);
+}
+
+const matrixOptions: MatrixOptions = {
+  ...LedMatrix.defaultMatrixOptions(),
+  rows,
+  cols,
+  chainLength,
+  hardwareMapping,
+};
+if (panel.pwnLsbNanoseconds !== undefined) {
+  matrixOptions.pwmLsbNanoseconds = panel.pwnLsbNanoseconds;
+}
+if (panel.pwmBits !== undefined) {
+  matrixOptions.pwmBits = panel.pwmBits;
+}
+
+console.log("rpi-led-matrix loaded OK");
+console.log(
+  `Config: rows=${rows} cols=${cols} chain=${chainLength} mapping=${mappingKey} ` +
+    `slowdown=${gpioSlowdown} brightness=${brightness} ` +
+    `pwmBits=${matrixOptions.pwmBits} pwmLsbNanoseconds=${matrixOptions.pwmLsbNanoseconds}`,
+);
+
+const matrix = new LedMatrix(matrixOptions, {
+  ...LedMatrix.defaultRuntimeOptions(),
+  gpioSlowdown,
+});
+
+console.log("LedMatrix constructed OK");
+
+const width = cols * chainLength;
+const height = rows;
+const colors = [0xff0000, 0x00ff00, 0x0000ff, 0xffffff];
+let frame = 0;
+
+matrix.afterSync(() => {
+  matrix.clear().brightness(brightness);
+
+  // Phase 1 (first ~4s): solid color fills, one per second.
+  if (frame < 4 * 30) {
+    const color = colors[Math.floor(frame / 30) % colors.length];
+    matrix.fgColor(color).fill();
+  } else {
+    // Phase 2: a single white pixel sweeping across the panel.
+    const i = frame % (width * height);
+    const x = i % width;
+    const y = Math.floor(i / width);
+    matrix.fgColor(0xffffff).setPixel(x, y);
+  }
+
+  frame++;
+  setTimeout(() => matrix.sync(), 1000 / 30); // ~30fps
+});
+
+console.log(
+  "Starting render loop — you should see R/G/B/white fills, then a sweeping pixel.",
+);
+matrix.sync();


### PR DESCRIPTION
## Summary
- Adds `hardware/test-matrix.ts`, a standalone smoke test that constructs an `LedMatrix` and runs a short render loop (R/G/B/white fills, then a sweeping pixel) to isolate the matrix + HAT from the rest of the app.
- Bundles it via `build.js` to `dist/hardware/test-matrix.cjs`, next to the prebuilt `rpi-led-matrix.node`, so it runs on a deployed release with no `node_modules`.
- Refactors the shared esbuild config and the native-module path rewrite into reusable helpers (`esbuildOptions`, `rewriteNativeModulePaths`) so the hardware bundle and the smoke test go through identical logic.

## Why
While debugging a SIGILL crash on a Raspberry Pi after an Adafruit HAT install, we needed a way to exercise just the `rpi-led-matrix` native module on the deployed release without pulling in the app, db, or skia. The release ships bundled `.cjs` files with prebuilt natives and no `node_modules`, so the test has to be bundled the same way.

## Usage (on the Pi)
```bash
sudo systemctl stop moonclock-hardware   # release the panel first
cd /usr/local/bin/moonclock/current/dist/hardware
sudo node test-matrix.cjs
# options: --rows --cols --chain --mapping --slowdown --brightness
#          --panel='{"pwmBits":11,"pwnLsbNanoseconds":130,"gpioSlowdown":4,"brightness":50}'
sudo systemctl start moonclock-hardware
```

## Test plan
- [ ] `npm run build` produces `dist/hardware/test-matrix.cjs` with the `.node` path rewritten to `./build/rpi-led-matrix.node`
- [ ] On a Pi, `sudo node test-matrix.cjs` from a deployed release lights the panel (R/G/B/white, then sweeping pixel)
- [ ] `--panel` JSON and individual flags resolve as echoed in the startup config line

🤖 Generated with [Claude Code](https://claude.com/claude-code)