### PR TITLE
Fix stuck half-green panel from stale double-buffer

### DIFF
--- a/hardware/index.ts
+++ b/hardware/index.ts
@@ -159,11 +159,19 @@ export async function createCanvas(dimensions: Dimensions) {
 
       if (pixelUpdates) {
         for (const pixel of pixelUpdates) {
-          const hexA = updateVirtualPanel(pixel);
-          matrix
-            .brightness(brightness || panel[PanelField.Brightness])
-            .fgColor(parseInt(hexA, 16))
-            .setPixel(pixel.x, pixel.y);
+          updateVirtualPanel(pixel);
+        }
+      }
+
+      // rpi-led-matrix double-buffers: the buffer drawn here is two syncs old,
+      // so drawing only the delta leaves the alternate buffer with stale or
+      // uninitialized data (e.g. a stuck half-green panel). Repaint the whole
+      // frame each sync from virtualPanel, which holds the full current state.
+      matrix.brightness(brightness || panel[PanelField.Brightness]);
+      for (let x = 0; x < 32; x++) {
+        for (let y = 0; y < 32; y++) {
+          const hexA = virtualPanel[x + ":" + y] ?? "000000";
+          matrix.fgColor(parseInt(hexA, 16)).setPixel(x, y);
         }
       }
 


### PR DESCRIPTION
## Summary
- The hardware render loop only drew the per-frame **delta** pixels into the matrix. Since `rpi-led-matrix` double-buffers, the buffer drawn in `afterSync` is two syncs old, so the alternate buffer kept stale/uninitialized data — most visibly a stuck **half-green panel** that persisted even with a blank preset.
- Now every `afterSync` repaints the entire 32×32 frame from `virtualPanel` (which already tracks the full current pixel state; unset pixels default to black), matching the library's documented full-redraw pattern. The delta queue is still consumed to keep `virtualPanel` up to date.

## Why
Diagnosed alongside the rpi-led-matrix smoke test (#120): the smoke test ran the panel correctly with the exact same panel config (`pwmBits`/`pwnLsbNanoseconds`/`gpioSlowdown`/`AdafruitHat`), which ruled out the hardware, the HAT, and the matrix configuration. The smoke test fully repaints each frame; the hardware service only painted deltas. That difference is the bug — the `Regular → AdafruitHat` mapping change just made the previously-harmless stale buffer render as green.

## Test plan
- [ ] On the Pi, confirm the half-green is gone at idle / with a blank preset
- [ ] Confirm presets and animations (Moon, Bunny, Ripple, Emoji, marquee, etc.) still render correctly
- [ ] Watch for flicker at the higher per-frame draw cost (1024 setPixel calls/frame; the library docs say this is the intended pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)