### PR TITLE
Disable button to fix half-green panel (GPIO16/G2 conflict)

### DIFF
--- a/hardware/index.ts
+++ b/hardware/index.ts
@@ -2,18 +2,14 @@ import { LedMatrix, GpioMapping } from "rpi-led-matrix";
 import { checkForNewDisplayConfig } from "./checkForNewDisplayConfig";
 import { createDisplayEngine } from "../src/display-engine";
 import { Dimensions, Macro, Pixel } from "../src/display-engine/types";
-import {
-  coordinates,
-  loadingBar,
-  marquee,
-  text,
-} from "../src/display-engine/marcoConfigs";
-import { getData, setData } from "@/server/db";
-import { getEndDate } from "@/helpers/getEndDate";
+import { coordinates, marquee, text } from "../src/display-engine/marcoConfigs";
+import { getData } from "@/server/db";
 import { transformPresetToDisplayMacros } from "@/server/actions/transformPresetToDisplayMacros";
 import { PanelField, Preset, PresetField, QueuedFramesSnapshot } from "@/types";
 import { Canvas, FontLibrary } from "skia-canvas";
-import { Gpio } from "onoff";
+// Disabled: the button uses GPIO16, which the AdafruitHat mapping drives as
+// G2 (green, bottom half). See the commented-out button block below.
+// import { Gpio } from "onoff";
 
 import express from "express";
 import { waitForIpAddress } from "./getIpAddress";
@@ -159,19 +155,11 @@ export async function createCanvas(dimensions: Dimensions) {
 
       if (pixelUpdates) {
         for (const pixel of pixelUpdates) {
-          updateVirtualPanel(pixel);
-        }
-      }
-
-      // rpi-led-matrix double-buffers: the buffer drawn here is two syncs old,
-      // so drawing only the delta leaves the alternate buffer with stale or
-      // uninitialized data (e.g. a stuck half-green panel). Repaint the whole
-      // frame each sync from virtualPanel, which holds the full current state.
-      matrix.brightness(brightness || panel[PanelField.Brightness]);
-      for (let x = 0; x < 32; x++) {
-        for (let y = 0; y < 32; y++) {
-          const hexA = virtualPanel[x + ":" + y] ?? "000000";
-          matrix.fgColor(parseInt(hexA, 16)).setPixel(x, y);
+          const hexA = updateVirtualPanel(pixel);
+          matrix
+            .brightness(brightness || panel[PanelField.Brightness])
+            .fgColor(parseInt(hexA, 16))
+            .setPixel(pixel.x, pixel.y);
         }
       }
 
@@ -282,6 +270,7 @@ export async function createCanvas(dimensions: Dimensions) {
     }
   }
 
+  /*
   try {
     const button = new Gpio(528, "in", "falling", { debounceTimeout: 50 });
     let currentPinnedIndex = -1;
@@ -402,6 +391,7 @@ export async function createCanvas(dimensions: Dimensions) {
     console.error("[HARDWARE] Button functionality will be disabled");
     console.error("[HARDWARE] See instructions in README.");
   }
+  */
 
   setInterval(async () => {
     await runConditionalRenderUpdate();


### PR DESCRIPTION
## Summary
- **Root cause:** the button claimed BCM **GPIO16** via `onoff`, but the `AdafruitHat` mapping drives GPIO16 as **G2** (green, lower 16 rows). Holding it as an input corrupted the bottom half of the panel (stuck green) and left brightness ineffective on that half. It surfaced exactly when the mapping changed `Regular → AdafruitHat` (the first mapping to use GPIO16).
- Comments out the button init + its `onoff` import (and the three imports only it used) until the button can be rewired to a free GPIO.
- **Reverts the full-frame repaint from #121.** That change was a wrong guess at the cause (double-buffer staleness); it didn't fix anything and only added a 1024-`setPixel`/frame cost. Restores the original delta-draw `afterSync` loop.

## How it was isolated
The rpi-led-matrix smoke test (#120) ran the panel perfectly with the *exact* same panel config — but it never inits the button. index.ts does. That, plus "brightness has no effect on the green half," pointed straight at a GPIO pin collision on the G2 line.

## Follow-up
The button is **disabled, not relocated** — it does nothing until rewired. Pins the AdafruitHat mapping leaves free include GPIO25 (pin 22) and GPIO19 (pin 35). A future change can move the button to one of those and re-enable the block.

## Test plan
- [ ] On the Pi (AdafruitHat), confirm the bottom-half green is gone and the full panel renders correctly
- [ ] Confirm brightness adjustment now affects the whole panel
- [ ] Confirm presets/animations render as before (delta-draw restored)
- [ ] Cut a release after merge so the Pi actually receives the fix (0.90.1 shipped the bad repaint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)