### PR TITLE
settings: make hardware mapping and button GPIO configurable

### DIFF
--- a/hardware/index.ts
+++ b/hardware/index.ts
@@ -2,14 +2,12 @@ import { LedMatrix, GpioMapping } from "rpi-led-matrix";
 import { checkForNewDisplayConfig } from "./checkForNewDisplayConfig";
 import { createDisplayEngine } from "../src/display-engine";
 import { Dimensions, Macro, Pixel } from "../src/display-engine/types";
-import { coordinates, marquee, text } from "../src/display-engine/marcoConfigs";
-import { getData } from "@/server/db";
+import { coordinates, marquee, text, loadingBar } from "../src/display-engine/marcoConfigs";
+import { getData, setData } from "@/server/db";
 import { transformPresetToDisplayMacros } from "@/server/actions/transformPresetToDisplayMacros";
 import { PanelField, Preset, PresetField, QueuedFramesSnapshot } from "@/types";
 import { Canvas, FontLibrary } from "skia-canvas";
-// Disabled: the button uses GPIO16, which the AdafruitHat mapping drives as
-// G2 (green, bottom half). See the commented-out button block below.
-// import { Gpio } from "onoff";
+import { getEndDate } from "@/helpers/getEndDate";
 
 import express from "express";
 import Bonjour from "bonjour-service";
@@ -154,7 +152,7 @@ export async function createCanvas(dimensions: Dimensions) {
         rows: 32,
         cols: 32,
         chainLength: 1,
-        hardwareMapping: GpioMapping.AdafruitHat,
+        hardwareMapping: panel[PanelField.HardwareMapping] as GpioMapping,
         pwmLsbNanoseconds: panel[PanelField.PwnLsbNanoseconds],
         pwmBits: panel[PanelField.PwmBits],
       },
@@ -285,128 +283,136 @@ export async function createCanvas(dimensions: Dimensions) {
     }
   }
 
-  /*
-  try {
-    const button = new Gpio(528, "in", "falling", { debounceTimeout: 50 });
-    let currentPinnedIndex = -1;
-    let activePreview: {
-      timeoutId: NodeJS.Timeout | null;
-      cancelled: boolean;
-    } | null = null;
-
-    button.watch(async (err) => {
-      if (err) {
-        console.error("[HARDWARE] Button watch error:", err);
-        return;
-      }
-
-      if (activePreview) {
-        activePreview.cancelled = true;
-        if (activePreview.timeoutId) clearTimeout(activePreview.timeoutId);
-      }
-      const op: { timeoutId: NodeJS.Timeout | null; cancelled: boolean } = {
-        timeoutId: null,
-        cancelled: false,
-      };
-      activePreview = op;
-
-      console.log(
-        "[HARDWARE] Button pressed! Cycling to next pinned preset...",
+  if (panel[PanelField.ButtonEnabled]) {
+    try {
+      const { Gpio } = await import("onoff");
+      const button = new Gpio(
+        panel[PanelField.ButtonGpioPin],
+        "in",
+        "falling",
+        { debounceTimeout: 50 },
       );
+      let currentPinnedIndex = -1;
+      let activePreview: {
+        timeoutId: NodeJS.Timeout | null;
+        cancelled: boolean;
+      } | null = null;
 
-      const { presets } = getData();
-      const pinnedPresets = presets.filter((p) => p[PresetField.Pinned]);
-
-      if (pinnedPresets.length === 0) {
-        console.log("[HARDWARE] No pinned presets found");
-        return;
-      }
-
-      currentPinnedIndex =
-        (currentPinnedIndex + 1) % (pinnedPresets.length + 1);
-
-      if (currentPinnedIndex === pinnedPresets.length) {
-        console.log("[HARDWARE] Clearing scheduled preset");
-
-        setData({
-          scheduledPreset: null,
-        });
-      } else {
-        const nextPreset = pinnedPresets[currentPinnedIndex];
-
-        console.log(
-          `[HARDWARE] Switching to preset: ${nextPreset[PresetField.Name]}`,
-        );
-
-        const endDate = getEndDate(nextPreset);
-
-        if (endDate) {
-          const hours24 = endDate.getHours();
-          const hours12 = hours24 % 12 || 12;
-          const minutes = endDate.getMinutes().toString().padStart(2, "0");
-          const period = hours24 >= 12 ? "PM" : "AM";
-          const endTimeText = `${hours12}:${minutes} ${period}`;
-
-          const previewDurationMs = 3000;
-
-          engine.render([
-            text({
-              text: nextPreset[PresetField.Name],
-              font: "Tiny5",
-              color: "#FFF",
-              fontSize: 8,
-              startingRow: 1,
-            }),
-            text({
-              text: `Until..`,
-              font: "Tiny5",
-              color: "#999",
-              fontSize: 8,
-              startingRow: 9,
-            }),
-            text({
-              text: endTimeText,
-              font: "Tiny5",
-              color: "#999",
-              fontSize: 8,
-              startingRow: 18,
-            }),
-            loadingBar({
-              duration: previewDurationMs,
-              color: "#009900",
-              height: 1,
-            }),
-          ]);
-
-          await new Promise<void>((resolve) => {
-            op.timeoutId = setTimeout(resolve, previewDurationMs);
-          });
-
-          if (op.cancelled) {
-            console.log("[HARDWARE] Operation aborted by new button press");
-            return;
-          }
+      button.watch(async (err) => {
+        if (err) {
+          console.error("[HARDWARE] Button watch error:", err);
+          return;
         }
 
-        setData({
-          scheduledPreset: {
-            preset: nextPreset,
-            endTime: endDate ? endDate.toJSON() : null,
-            updatedAt: new Date().toJSON(),
-          },
-        });
-      }
+        if (activePreview) {
+          activePreview.cancelled = true;
+          if (activePreview.timeoutId) clearTimeout(activePreview.timeoutId);
+        }
+        const op: { timeoutId: NodeJS.Timeout | null; cancelled: boolean } = {
+          timeoutId: null,
+          cancelled: false,
+        };
+        activePreview = op;
 
-      await runConditionalRenderUpdate();
-    });
+        console.log(
+          "[HARDWARE] Button pressed! Cycling to next pinned preset...",
+        );
 
-    console.log("[HARDWARE] Button initialized on GPIO 528 (pin 36)");
-  } catch (error) {
-    console.error("[HARDWARE] Failed to initialize button GPIO:", error);
-    console.error("[HARDWARE] Button functionality will be disabled");
-    console.error("[HARDWARE] See instructions in README.");
+        const { presets } = getData();
+        const pinnedPresets = presets.filter((p) => p[PresetField.Pinned]);
+
+        if (pinnedPresets.length === 0) {
+          console.log("[HARDWARE] No pinned presets found");
+          return;
+        }
+
+        currentPinnedIndex =
+          (currentPinnedIndex + 1) % (pinnedPresets.length + 1);
+
+        if (currentPinnedIndex === pinnedPresets.length) {
+          console.log("[HARDWARE] Clearing scheduled preset");
+
+          setData({
+            scheduledPreset: null,
+          });
+        } else {
+          const nextPreset = pinnedPresets[currentPinnedIndex];
+
+          console.log(
+            `[HARDWARE] Switching to preset: ${nextPreset[PresetField.Name]}`,
+          );
+
+          const endDate = getEndDate(nextPreset);
+
+          if (endDate) {
+            const hours24 = endDate.getHours();
+            const hours12 = hours24 % 12 || 12;
+            const minutes = endDate.getMinutes().toString().padStart(2, "0");
+            const period = hours24 >= 12 ? "PM" : "AM";
+            const endTimeText = `${hours12}:${minutes} ${period}`;
+
+            const previewDurationMs = 3000;
+
+            engine.render([
+              text({
+                text: nextPreset[PresetField.Name],
+                font: "Tiny5",
+                color: "#FFF",
+                fontSize: 8,
+                startingRow: 1,
+              }),
+              text({
+                text: `Until..`,
+                font: "Tiny5",
+                color: "#999",
+                fontSize: 8,
+                startingRow: 9,
+              }),
+              text({
+                text: endTimeText,
+                font: "Tiny5",
+                color: "#999",
+                fontSize: 8,
+                startingRow: 18,
+              }),
+              loadingBar({
+                duration: previewDurationMs,
+                color: "#009900",
+                height: 1,
+              }),
+            ]);
+
+            await new Promise<void>((resolve) => {
+              op.timeoutId = setTimeout(resolve, previewDurationMs);
+            });
+
+            if (op.cancelled) {
+              console.log("[HARDWARE] Operation aborted by new button press");
+              return;
+            }
+          }
+
+          setData({
+            scheduledPreset: {
+              preset: nextPreset,
+              endTime: endDate ? endDate.toJSON() : null,
+              updatedAt: new Date().toJSON(),
+            },
+          });
+        }
+
+        await runConditionalRenderUpdate();
+      });
+
+      console.log(
+        `[HARDWARE] Button initialized on GPIO ${panel[PanelField.ButtonGpioPin]}`,
+      );
+    } catch (error) {
+      console.error("[HARDWARE] Failed to initialize button GPIO:", error);
+      console.error("[HARDWARE] Button functionality will be disabled");
+      console.error("[HARDWARE] See instructions in README.");
+    }
   }
-  */
 
   setInterval(async () => {
     await runConditionalRenderUpdate();

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start:dev": "concurrently \"npm run app:dev\" \"npm run hardware:dev\"",
     "test:e2e": "playwright test",
     "test:e2e:debug": "PWDEBUG=1 playwright test",
-    "test": "APP_ENV=test tsx --test",
+    "test": "APP_ENV=test tsx --test $(find . -name '*.test.ts' -not -path '*/node_modules/*')",
     "release": "bin/release.sh"
   },
   "dependencies": {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -7,9 +7,11 @@ import {
   Button,
   Divider,
   Group,
+  NumberInput,
   Select,
   Slider,
   Stack,
+  Switch,
   Text,
   TextInput,
   Title,
@@ -172,7 +174,7 @@ export function Settings({ panel, customSceneNames }: SettingsProps) {
                 </Stack>
 
                 <Stack gap={4}>
-                  <Stack gap={0}>
+                  <Stack gap={4}>
                     <Text size="sm">PWN Bits</Text>
                     <Text c="dimmed" size="xs">
                       Lower values will increase performance at the expense of
@@ -185,6 +187,41 @@ export function Settings({ panel, customSceneNames }: SettingsProps) {
                     key={form.key(PanelField.PwmBits)}
                     {...form.getInputProps(PanelField.PwmBits)}
                   />
+                </Stack>
+
+                <Select
+                  label="Hardware Mapping"
+                  description="GPIO wiring layout for your LED matrix HAT or adapter"
+                  variant="filled"
+                  data={[
+                    { label: "Regular", value: "regular" },
+                    { label: "Adafruit HAT", value: "adafruit-hat" },
+                    { label: "Adafruit HAT (PWM)", value: "adafruit-hat-pwm" },
+                    { label: "Regular (Pi 1)", value: "regular-pi1" },
+                  ]}
+                  key={form.key(PanelField.HardwareMapping)}
+                  {...form.getInputProps(PanelField.HardwareMapping)}
+                />
+
+                <Stack gap={4}>
+                  <Switch
+                    label="Enable Button"
+                    description="Enable GPIO button to cycle through pinned presets"
+                    key={form.key(PanelField.ButtonEnabled)}
+                    {...form.getInputProps(PanelField.ButtonEnabled, {
+                      type: "checkbox",
+                    })}
+                  />
+                  {form.getValues()[PanelField.ButtonEnabled] && (
+                    <NumberInput
+                      label="Button GPIO Pin"
+                      description="GPIO chip-relative offset for the button (e.g. 528 for BCM GPIO16)"
+                      variant="filled"
+                      min={0}
+                      key={form.key(PanelField.ButtonGpioPin)}
+                      {...form.getInputProps(PanelField.ButtonGpioPin)}
+                    />
+                  )}
                 </Stack>
               </Stack>
             </Accordion.Panel>

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -22,6 +22,9 @@ export const defaultData: DataTypes = {
     pwnLsbNanoseconds: 130,
     gpioSlowdown: 4,
     pwmBits: 11,
+    hardwareMapping: "adafruit-hat",
+    buttonEnabled: false,
+    buttonGpioPin: 528,
   },
   scheduledPreset: {
     preset: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,9 @@ export interface Panel {
   [PanelField.GpioSlowdown]: 0 | 1 | 2 | 3 | 4;
   [PanelField.PwmBits]: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
   [PanelField.AnthropicApiKey]?: string;
+  [PanelField.HardwareMapping]: string;
+  [PanelField.ButtonEnabled]: boolean;
+  [PanelField.ButtonGpioPin]: number;
   updatedAt?: string;
   defaultPreset: Preset;
 }
@@ -43,6 +46,9 @@ export enum PanelField {
   GpioSlowdown = "gpioSlowdown",
   PwmBits = "pwmBits",
   AnthropicApiKey = "anthropicApiKey",
+  HardwareMapping = "hardwareMapping",
+  ButtonEnabled = "buttonEnabled",
+  ButtonGpioPin = "buttonGpioPin",
 }
 
 export interface Time {


### PR DESCRIPTION
## What

Makes the LED matrix hardware mapping and the physical button (enable/disable + GPIO pin) configurable from the Settings UI, rather than hardcoded in `hardware/index.ts`.

## Why

Two recent commits exposed a need for this:
- `903b5ad` hardcoded `GpioMapping.AdafruitHat` — different hardware setups need different mappings (Regular, Adafruit HAT PWM, Pi1, etc.)
- `15cb694` disabled the button entirely because GPIO16 (pin 528) conflicts with the AdafruitHat's G2 signal. The right fix is to let users pick a conflict-free GPIO pin when they rewire the button, and opt in explicitly.

## Changes

- **`src/types.ts`** — Added `HardwareMapping`, `ButtonEnabled`, `ButtonGpioPin` to `PanelField` enum and `Panel` interface
- **`src/server/db.ts`** — Defaults: `hardwareMapping: "adafruit-hat"`, `buttonEnabled: false`, `buttonGpioPin: 528`
- **`src/components/Settings.tsx`** — Added to the Advanced Settings accordion:
  - Hardware Mapping `<Select>` (Regular / Adafruit HAT / Adafruit HAT PWM / Regular Pi1)
  - Button Enabled `<Switch>`
  - Button GPIO Pin `<NumberInput>` (visible only when button is enabled)
- **`hardware/index.ts`** — Uses `panel[PanelField.HardwareMapping]` instead of hardcoded `AdafruitHat`; button block re-enabled and guarded by `panel[PanelField.ButtonEnabled]`, using the configurable pin. Also fixed previously-hidden missing imports (`setData`, `getEndDate`, `loadingBar`) that were only obscured by the commented-out button code.

## Notes for reviewers

- Button defaults to **disabled** — preserves safe existing behavior. Users must explicitly enable it after rewiring to a GPIO that doesn't conflict with their chosen hardware mapping.
- The hardware mapping default stays `adafruit-hat` to match the current hardcoded value, so existing installs are unaffected.