### PR TITLE
Fix animation-loop leak slowing down /presets previews

### DIFF
--- a/src/components/PresetPreview.tsx
+++ b/src/components/PresetPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { createDisplayEngine, Dimensions, Macro } from "../display-engine";
 import { Preset } from "@/types";
 import { transformPresetToDisplayMacros } from "@/server/actions/transformPresetToDisplayMacros";
@@ -39,6 +39,8 @@ export function PresetPreview({
 
   const [engine, setEngine] = useState<any>();
 
+  const engineRef = useRef<any>(null);
+
   const [displayConfig, setDisplayConfig] = useState<Macro[]>([]);
 
   useEffect(() => {
@@ -48,6 +50,8 @@ export function PresetPreview({
   }, [JSON.stringify(preset)]);
 
   useEffect(() => {
+    let cancelled = false;
+
     (async () => {
       const canvas = await createCanvas(dimensions);
       const ctx = canvas.getContext("2d");
@@ -80,10 +84,21 @@ export function PresetPreview({
         },
       });
 
+      // The component may have unmounted while the engine was being created
+      // asynchronously; stop it immediately so it never starts running.
+      if (cancelled) {
+        displayEngine.stop();
+        return;
+      }
+
+      engineRef.current = displayEngine;
       setEngine(displayEngine);
     })();
 
-    return () => engine?.stop();
+    return () => {
+      cancelled = true;
+      engineRef.current?.stop();
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

The `/presets` page gets progressively slower the more often it is opened. Preset previews become choppy and laggy, and only a full page reload restores performance (SPA navigation does not).

## Root cause

Each `PresetPreview` creates a display engine whose animated macros (twinkle, marquee, meteors, ripple) run recursive `setTimeout` loops. Those loops are only stopped when the engine's cleanup runs.

In `PresetPreview.tsx`, the mount effect's cleanup was `return () => engine?.stop()` with an empty dependency array. Because the effect runs once at mount, its cleanup closure captured `engine` from state while it was still `undefined`. On unmount, `engine?.stop()` was therefore a no-op, and the engine that was actually created (along with its running animation timers) was never stopped.

Every visit to `/presets` mounted fresh previews that started new animation loops which were never torn down. Orphaned loops accumulated across navigations, all competing for the main thread and repeatedly running canvas work + `toDataURL()`, so the previews on the current visit got slower the more often the page was opened.

## Fix

- Hold the engine in a `useRef` so the cleanup can reach the actual instance and stop it on unmount.
- Guard the async creation race: if the component unmounts before the engine finishes being created, stop it immediately so it never starts running.

## Testing

- `tsc --noEmit` passes.
- ESLint clean (only a pre-existing `<img>` warning unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)